### PR TITLE
propose RFC process (meta proposal)

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,0 +1,88 @@
+- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: [nushell/rfcs#0000](https://github.com/nushell/rfcs/pull/0000)
+- Nushell Issue: [nushell/nushell#0000](https://github.com/nushell/nushell/issues/0000)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in Nu and you were teaching it to another Nu user. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Nu users should *think* about the feature, and how it should impact the way they use Nu. It should explain the impact as concretely as possible.
+- If applicable, provide sample syntax details like flags and arguments or sample error messages.
+- If applicable, describe the differences between teaching this to users of other shells.
+
+For implementation-oriented RFCs (e.g. for plugin architecture), this section should focus on how contributors should think about the change, and give examples of its concrete impact.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- Does this feature exist in other shells and what experience have their communities had?
+- Does this feature exist in comparable programming languages like SQL, that have similar keywords (think select, where)?
+- Are there similar features in Nu itself, that can provide guidance on designing this feature?
+
+This section is intended to encourage you as an author to think about the lessons from other shells or programming languages, providing readers of your RFC with a fuller picture. If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other solutions.
+
+Note that while precedent set by other shells is some motivation, it does not on its own motivate an RFC.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would
+be and how it would affect the project as a whole in a holistic way.
+
+This is also a good place to "dump ideas", if they are out of scope for the
+RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities,
+you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section
+is not a reason to accept the current or a future RFC; such notes should be
+in the section on motivation or rationale in this or subsequent RFCs.
+The section merely provides additional information.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The "RFC" (request for comments) process is intended to provide a consistent
 and controlled path for new features to be added to Nushell, so that all
 stakeholders can be confident about the direction the project is evolving in.
 
+In the context of this RFC process, all mentions of "team" refer to all
+commiters of the [main nushell repository on GitHub](https://github.com/nushell/nushell/).
 
 ## Table of Contents
 [Table of Contents]: #table-of-contents

--- a/README.md
+++ b/README.md
@@ -109,32 +109,15 @@ into Nushell.
     request, and leave a comment on the pull request explaining your changes.
     **Specifically, do not squash or rebase commits after they are visible on the
     pull request.**
-  - At some point, a member of the team will propose a "motion for final
-    comment period" (FCP), along with a *disposition* for the RFC (merge, close,
-    or postpone).
-    - This step is taken when enough of the tradeoffs have been discussed that
-      the team is in a position to make a decision. That does not require
-      consensus amongst all participants in the RFC thread (which is usually
-      impossible). However, the argument supporting the disposition on the RFC
-      needs to have already been clearly articulated, and there should not be a
-      strong consensus *against* that position. Team members use their best
-      judgment in taking this step, and the FCP itself ensures there is ample
-      time and notification for stakeholders to push back if it is made
-      prematurely.
-    - For RFCs with lengthy discussion, the motion to FCP is usually preceded by
-      a *summary comment* trying to lay out the current state of the discussion
-      and major tradeoffs/points of disagreement.
-    - Before actually entering FCP, *all* team members must sign off; this
-      might be the point at which many team members first review the RFC in full
-      depth.
-  - The FCP lasts ten calendar days, so that it is open for at least 5 business
-    days. It is also advertised widely,
-    e.g. in [This Week in Nushell](https://www.notion.so/This-Week-in-Nu-ed589e19f1be47fa9ef562c1757e7ba1).
+  - When the RFC is in a state that justifies community attention, it should be
+    advertised widely, e.g. in [This Week in Nushell](https://www.notion.so/This-Week-in-Nu-ed589e19f1be47fa9ef562c1757e7ba1).
     This way all stakeholders have a chance to lodge any final objections
     before a decision is reached.
-  - In most cases, the FCP period is quiet, and the RFC is either merged or
-    closed. However, sometimes substantial new arguments or ideas are raised,
-    the FCP is canceled, and the RFC goes back into development mode.
+  - At some point after advertising the RFC was advertised publicly, a member
+    of the team will propose a decision for the RFC (merge, close, or postpone).
+    Another team member must sign off on that decision, and can then take the
+    appropriate action. When closing or postponing, the reasons need to be well
+    documented in the PR.
 
 ## The RFC life-cycle
 [The RFC life-cycle]: #the-rfc-life-cycle
@@ -235,9 +218,9 @@ This RFC process started as partial copy of [Rust's RFCs repo](https://github.co
 In this case, their prior art helped us kick-start the RFC process, skipping many of the process work itself.
 
 Since Nushell at this time has no sub-teams, that concept was removed or
-replaced by "team" (implying commiters to the main nushell repo on GitHub.)
+replaced by "team" (implying commiters to the main nushell repo on GitHub).
 
-To give back a little, consider upstreaming improvements here as suggestions to them.
+The FCP stage was removed, to adjust the process towards Nushell's current needs.
 
 We're considering adding a [stage process similar to TC39](https://tc39.es/process-document/). For now we're starting without explicit stages.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ stakeholders can be confident about the direction the project is evolving in.
   - [Reviewing RFCs]
   - [Implementing an RFC]
   - [RFC Postponement]
-  - [Help this is all too informal!]
   - [License]
   - [Contributions]
   - [Acknowledgements]
@@ -226,14 +225,6 @@ informal first round of evaluation, namely the round of "do we think we would
 ever possibly consider making this change, as outlined in the RFC pull request,
 or some semi-obvious variation of it." (When the answer to the latter question
 is "no", then the appropriate response is to close the RFC, not postpone it.)
-
-
-### Help this is all too informal!
-[Help this is all too informal!]: #help-this-is-all-too-informal
-
-The process is intended to be as lightweight as reasonable for the present
-circumstances. As usual, we are trying to let the process be driven by
-consensus and community norms, not impose more structure than necessary.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ replaced by "team" (implying commiters to the main nushell repo on GitHub.)
 
 To give back a little, consider upstreaming improvements here as suggestions to them.
 
+We're considering adding a [stage process similar to TC39](https://tc39.es/process-document/). For now we're starting without explicit stages.
+
 
 [official Discord server]: https://discord.gg/NtAbbGn
 [RFC repository]: https://github.com/nushell/rfcs

--- a/README.md
+++ b/README.md
@@ -63,21 +63,12 @@ the RFC process, it may be closed with a polite request to submit an RFC first.
 ## Before creating an RFC
 [Before creating an RFC]: #before-creating-an-rfc
 
-A hastily-proposed RFC can hurt its chances of acceptance. Low quality
-proposals, proposals for previously-rejected features, or those that don't fit
-into the near-term roadmap, may be quickly rejected, which can be demotivating
-for the unprepared contributor. Laying some groundwork ahead of the RFC can
-make the process smoother.
-
-Although there is no single way to prepare for submitting an RFC, it is
-generally a good idea to pursue feedback from other project developers
+It is generally a good idea to pursue feedback from other project developers
 beforehand, to ascertain that the RFC may be desirable; having a consistent
 impact on the project requires concerted effort toward consensus-building.
 
 The most common preparations for writing and submitting an RFC include talking
-the idea over on our [official Discord server] (*maybe later, also a discussion
-forum*). You may file issues on this repo for discussion, but these are
-not as actively looked at by the team.
+the idea over on our [official Discord server], in #design-discussion. You could also file issues on this repo for discussion.
 
 As a rule of thumb, receiving encouraging feedback from long-standing project
 developers is a good indication that the RFC is worth pursuing.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Many changes, including bug fixes and documentation improvements can be
 implemented and reviewed via the normal GitHub pull request workflow.
 
-Though ssome changes are substantial enough that we ask for these to be
+Though some changes are substantial enough that we ask for these to be
 put through a bit of a design process and produce a consensus among the
 Nushell community.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ stakeholders can be confident about the direction the project is evolving in.
 
   - [Opening](#nushell-rfcs)
   - [Table of Contents]
-  - [When you need to follow this process]
+  - [When you should follow this process]
   - [Before creating an RFC]
   - [What the process is]
   - [The RFC life-cycle]
@@ -45,7 +45,7 @@ ecosystem you are proposing to change, but may include the following:
   - Removing existing features.
   - Changes to internal interfaces, like the plugin architecture.
 
-Some changes do not require an RFC:
+Some changes do not require an RFC. For example:
 
   - Rephrasing, reorganizing, refactoring, or otherwise "changing shape does
     not change meaning".
@@ -179,7 +179,8 @@ review after the RFC has been accepted.
 
 If you are interested in working on the implementation for an "active" RFC, but
 cannot determine if someone else is already working on it, feel free to ask
-(e.g. by leaving a comment on the associated issue).
+(e.g. by leaving a comment on the associated issue; a team member can then
+assign you to the issue). 
 
 
 ## RFC Postponement

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ next major release.
 
 In general, once accepted, RFCs should not be substantially changed. Only very
 minor changes should be submitted as amendments. More substantial changes
-should be new RFCs, with a note added to the original RFC. Exactly what counts
+should be new RFCs, with a note added to the original RFC. What exactly counts
 as a "very minor change" is up to the team to decide.
 
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,262 @@
+# Nushell RFCs
+
+[Nushell RFCs]: #nushell-rfcs
+
+Many changes, including bug fixes and documentation improvements can be
+implemented and reviewed via the normal GitHub pull request workflow.
+
+Though ssome changes are substantial enough that we ask for these to be
+put through a bit of a design process and produce a consensus among the
+Nushell community.
+
+The "RFC" (request for comments) process is intended to provide a consistent
+and controlled path for new features to be added to Nushell, so that all
+stakeholders can be confident about the direction the project is evolving in.
+
+
+## Table of Contents
+[Table of Contents]: #table-of-contents
+
+  - [Opening](#nushell-rfcs)
+  - [Table of Contents]
+  - [When you need to follow this process]
+  - [Before creating an RFC]
+  - [What the process is]
+  - [The RFC life-cycle]
+  - [Reviewing RFCs]
+  - [Implementing an RFC]
+  - [RFC Postponement]
+  - [Help this is all too informal!]
+  - [License]
+  - [Contributions]
+  - [Acknowledgements]
+
+
+## When you should follow this process
+[When you should follow this process]: #when-you-should-follow-this-process
+
+*Note: While we establish this RFC process, this says "should"; eventually
+it should say "need to".*
+
+You should follow this process if you intend to make substantial changes to
+Nushell, or this RFC process itself. What constitutes a substantial change is
+evolving based on community norms and varies depending on what part of the
+ecosystem you are proposing to change, but may include the following:
+
+  - Any semantic or syntactic change that is not a bugfix.
+  - Removing existing features.
+  - Changes to internal interfaces, like the plugin architecture.
+
+Some changes do not require an RFC:
+
+  - Rephrasing, reorganizing, refactoring, or otherwise "changing shape does
+    not change meaning".
+  - Additions that strictly improve objective, numerical quality criteria
+    (warning removal, speedup, better platform coverage, more parallelism,
+    better handle errors, etc.)
+  - Additions only likely to be _noticed by_ other developers of Nushell,
+    invisible to users of Nushell.
+
+If you submit a pull request to implement a new feature without going through
+the RFC process, it may be closed with a polite request to submit an RFC first.
+
+
+## Before creating an RFC
+[Before creating an RFC]: #before-creating-an-rfc
+
+A hastily-proposed RFC can hurt its chances of acceptance. Low quality
+proposals, proposals for previously-rejected features, or those that don't fit
+into the near-term roadmap, may be quickly rejected, which can be demotivating
+for the unprepared contributor. Laying some groundwork ahead of the RFC can
+make the process smoother.
+
+Although there is no single way to prepare for submitting an RFC, it is
+generally a good idea to pursue feedback from other project developers
+beforehand, to ascertain that the RFC may be desirable; having a consistent
+impact on the project requires concerted effort toward consensus-building.
+
+The most common preparations for writing and submitting an RFC include talking
+the idea over on our [official Discord server] (*maybe later, also a discussion
+forum*). You may file issues on this repo for discussion, but these are
+not as actively looked at by the team.
+
+As a rule of thumb, receiving encouraging feedback from long-standing project
+developers is a good indication that the RFC is worth pursuing.
+
+
+## What the process is
+[What the process is]: #what-the-process-is
+
+In short, to get a major feature added to Nushell, one must (for now: should)
+first get the RFC merged into the RFC repository as a markdown file. At that
+point the RFC is "active" and may be implemented with the goal of inclusion
+into Nushell.
+
+  - Fork the RFC repo [RFC repository]
+  - Copy `0000-template.md` to `text/0000-my-feature.md` (where "my-feature" is
+    descriptive. Leave the `0000` for now).
+  - Fill in the RFC. Put care into the details: RFCs that do not present
+    convincing motivation, demonstrate lack of understanding of the design's
+    impact, or are disingenuous about the drawbacks or alternatives tend to
+    be poorly-received.
+  - Submit a pull request. As a pull request the RFC will receive design
+    feedback from the larger community, and the author should be prepared to
+    revise it in response.
+  - Now that your RFC has an open pull request, use the issue number of the PR
+    to update your `0000-` prefix to that number.
+  - Where applicable, each pull request will be triaged by the team in a
+    future meeting and assigned to a member of the team.
+  - Build consensus and integrate feedback. RFCs that have broad support are
+    much more likely to make progress than those that don't receive any
+    comments. Feel free to reach out to the RFC assignee in particular to get
+    help identifying stakeholders and obstacles.
+  - The team will discuss the RFC pull request, as much as possible in the
+    comment thread of the pull request itself. Other discussion (e.g. on
+    Discord) will be summarized on the pull request comment thread.
+  - RFCs rarely go through this process unchanged, especially as alternatives
+    and drawbacks are shown. You can make edits, big and small, to the RFC to
+    clarify or change the design, but make changes as new commits to the pull
+    request, and leave a comment on the pull request explaining your changes.
+    **Specifically, do not squash or rebase commits after they are visible on the
+    pull request.**
+  - At some point, a member of the team will propose a "motion for final
+    comment period" (FCP), along with a *disposition* for the RFC (merge, close,
+    or postpone).
+    - This step is taken when enough of the tradeoffs have been discussed that
+      the team is in a position to make a decision. That does not require
+      consensus amongst all participants in the RFC thread (which is usually
+      impossible). However, the argument supporting the disposition on the RFC
+      needs to have already been clearly articulated, and there should not be a
+      strong consensus *against* that position. Team members use their best
+      judgment in taking this step, and the FCP itself ensures there is ample
+      time and notification for stakeholders to push back if it is made
+      prematurely.
+    - For RFCs with lengthy discussion, the motion to FCP is usually preceded by
+      a *summary comment* trying to lay out the current state of the discussion
+      and major tradeoffs/points of disagreement.
+    - Before actually entering FCP, *all* team members must sign off; this
+      might be the point at which many team members first review the RFC in full
+      depth.
+  - The FCP lasts ten calendar days, so that it is open for at least 5 business
+    days. It is also advertised widely,
+    e.g. in [This Week in Nushell](https://www.notion.so/This-Week-in-Nu-ed589e19f1be47fa9ef562c1757e7ba1).
+    This way all stakeholders have a chance to lodge any final objections
+    before a decision is reached.
+  - In most cases, the FCP period is quiet, and the RFC is either merged or
+    closed. However, sometimes substantial new arguments or ideas are raised,
+    the FCP is canceled, and the RFC goes back into development mode.
+
+## The RFC life-cycle
+[The RFC life-cycle]: #the-rfc-life-cycle
+
+Once an RFC becomes "active" then authors may implement it and submit the
+feature as a pull request to the Nushell repo. Being "active" is not a rubber
+stamp, and in particular still does not mean the feature will ultimately be
+merged; it does mean that in principle all the major stakeholders have agreed
+to the feature and are amenable to merging it.
+
+Furthermore, the fact that a given RFC has been accepted and is "active"
+implies nothing about what priority is assigned to its implementation, nor does
+it imply anything about whether a Nushell developer has been assigned the task of
+implementing the feature. While it is not *necessary* that the author of the
+RFC also write the implementation, it is by far the most effective way to see
+an RFC through to completion: authors should not expect that other project
+developers will take on responsibility for implementing their accepted feature.
+
+Modifications to "active" RFCs can be done in follow-up pull requests. We
+strive to write each RFC in a manner that it will reflect the final design of
+the feature; but the nature of the process means that we cannot expect every
+merged RFC to actually reflect what the end result will be at the time of the
+next major release.
+
+In general, once accepted, RFCs should not be substantially changed. Only very
+minor changes should be submitted as amendments. More substantial changes
+should be new RFCs, with a note added to the original RFC. Exactly what counts
+as a "very minor change" is up to the team to decide.
+
+
+## Reviewing RFCs
+[Reviewing RFCs]: #reviewing-rfcs
+
+While the RFC pull request is up, the team may schedule meetings with the
+author and/or relevant stakeholders to discuss the issues in greater detail,
+and in some cases the topic may be discussed at a team meeting. In either
+case a summary from the meeting will be posted back to the RFC pull request.
+
+The team makes final decisions about RFCs after the benefits and drawbacks
+are well understood. These decisions can be made at any time, but the team
+will regularly issue decisions. When a decision is made, the RFC pull request
+will either be merged or closed. In either case, if the reasoning is not clear
+from the discussion in thread, the team will add a comment describing the
+rationale for the decision.
+
+
+## Implementing an RFC
+[Implementing an RFC]: #implementing-an-rfc
+
+Some accepted RFCs represent vital features that need to be implemented right
+away. Other accepted RFCs can represent features that can wait until some
+arbitrary developer feels like doing the work. Every accepted RFC has an
+associated issue tracking its implementation in the Nushell repository; thus that
+associated issue can be assigned a priority via the triage process that the
+team uses for all issues in the Nushell repository.
+
+The author of an RFC is not obligated to implement it. Of course, the RFC
+author (like any other developer) is welcome to post an implementation for
+review after the RFC has been accepted.
+
+If you are interested in working on the implementation for an "active" RFC, but
+cannot determine if someone else is already working on it, feel free to ask
+(e.g. by leaving a comment on the associated issue).
+
+
+## RFC Postponement
+[RFC Postponement]: #rfc-postponement
+
+Some RFC pull requests are tagged with the "postponed" label when they are
+closed (as part of the rejection process). An RFC closed with "postponed" is
+marked as such because we want neither to think about evaluating the proposal
+nor about implementing the described feature until some time in the future, and
+we believe that we can afford to wait until then to do so. This could be used
+to postpone features until after 1.0. Postponed pull requests may be re-opened
+when the time is right. We don't have any formal process for that.
+
+Usually an RFC pull request marked as "postponed" has already passed an
+informal first round of evaluation, namely the round of "do we think we would
+ever possibly consider making this change, as outlined in the RFC pull request,
+or some semi-obvious variation of it." (When the answer to the latter question
+is "no", then the appropriate response is to close the RFC, not postpone it.)
+
+
+### Help this is all too informal!
+[Help this is all too informal!]: #help-this-is-all-too-informal
+
+The process is intended to be as lightweight as reasonable for the present
+circumstances. As usual, we are trying to let the process be driven by
+consensus and community norms, not impose more structure than necessary.
+
+
+## License
+[License]: #license
+
+This repository is licensed under the MIT license ([LICENSE](LICENSE) or http://opensource.org/licenses/MIT)
+
+
+### Contributions
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+
+## Acknowledgements
+
+This RFC process started as partial copy of [Rust's RFCs repo](https://github.com/rust-lang/rfcs).
+In this case, their prior art helped us kick-start the RFC process, skipping many of the process work itself.
+
+Since Nushell at this time has no sub-teams, that concept was removed or
+replaced by "team" (implying commiters to the main nushell repo on GitHub.)
+
+To give back a little, consider upstreaming improvements here as suggestions to them.
+
+
+[official Discord server]: https://discord.gg/NtAbbGn
+[RFC repository]: https://github.com/nushell/rfcs

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ stakeholders can be confident about the direction the project is evolving in.
   - [Implementing an RFC]
   - [RFC Postponement]
   - [License]
-  - [Contributions]
   - [Acknowledgements]
 
 
@@ -205,11 +204,6 @@ is "no", then the appropriate response is to close the RFC, not postpone it.)
 [License]: #license
 
 This repository is licensed under the MIT license ([LICENSE](LICENSE) or http://opensource.org/licenses/MIT)
-
-
-### Contributions
-
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
 
 
 ## Acknowledgements

--- a/text/0001-establish-rfc-process.md
+++ b/text/0001-establish-rfc-process.md
@@ -1,0 +1,55 @@
+- Feature Name: establish-rfc-process
+- Start Date: 2020-05-30
+- RFC PR: [nushell/rfcs#0001](https://github.com/nushell/rfcs/pull/1)
+- Nushell Issue: [nushell/nushell#0000](https://github.com/nushell/nushell/issues/0000)
+
+# Summary
+[summary]: #summary
+
+Establish an RFC process, copying Rust's process.
+
+# Motivation
+[motivation]: #motivation
+
+Adding, extending and changing commands and their sytanx, flags and other behaviour is currently happening ad-hoc, via GitHub issues and PRs, sometimes with previous discussion on Discord. To establish a process for proposing, reviewing, accepting and implementing, or rejecting such changes, we want to copy what already works well for Rust.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Since this meta-RFC adds `0000-template.md` and `README.md` itself, all details can be found in those two files. Only changes to the RFC process should be allowed exceptions like this.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+See above.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+While we're pre-1.0, being able to quickly change Nushell, without much discussion, might be more desirable than this formal process.
+
+To soften the blow, for now the instruction is "should use this process", not "needs to use this process". Closer or post-1.0 that language should be changed to "needs to".
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+I've only looked at how Rust is doing it, so there might be better options.
+
+The impact of not doing this could be high churn and overhead of designing only in code, with unclear pathways for discussing designs upfront.
+
+# Prior art
+[prior-art]: #prior-art
+
+This started as a copy of Rust's RFC process, as indicated in the (additional) Achknowledgements section in the README. Their [README file](https://github.com/rust-lang/rfcs/blob/master/README.md) alone has had 29 contributiors at the time of writing this, and had plenty of time to evolve since its inception in March 2014.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+The concept of the "team" is currently not well defined (to my knowledge). It doesn't exist in Rust, which instead has sub-teams (for compiler, language and libraries). Actually defining "team" for Nushell, for example as all commiters to the nushell/nushell repostiroy, would be a potential solution.
+
+If that is undesirable, some aspects of the RFC process have to be changed (search for all mentions of "team" in the README and adjust them). For example accepting RFCs might have to be done by a minimum number of commiters, instead of "all team members".
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Eventually it might be a good idea for Nushell to also establish sub-teams. In that case, it would be helpful to look again how Rust specifies sub-team specific rules and processes.

--- a/text/0001-establish-rfc-process.md
+++ b/text/0001-establish-rfc-process.md
@@ -45,9 +45,10 @@ This started as a copy of Rust's RFC process, as indicated in the (additional) A
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-The concept of the "team" is currently not well defined (to my knowledge). It doesn't exist in Rust, which instead has sub-teams (for compiler, language and libraries). Actually defining "team" for Nushell, for example as all commiters to the nushell/nushell repostiroy, would be a potential solution.
+None.
 
-If that is undesirable, some aspects of the RFC process have to be changed (search for all mentions of "team" in the README and adjust them). For example accepting RFCs might have to be done by a minimum number of commiters, instead of "all team members".
+Resolved in the RFC process:
+* "Sub-teams" were replaced by "team", defined as "all commiters to the main nushell repository on GitHub".
 
 # Future possibilities
 [future-possibilities]: #future-possibilities


### PR DESCRIPTION
As discussed on Discord, I've copied parts of Rust's RFC process and adapted it to Nushell. Changing the template was pretty easy, changing the README was much much more work. Accordingly I expect that to need a much more thorough review.

Diffing against the original might help; I could add that as a gist later.

I noticed a few small issues in the original README and submitted that as a PR to their repo: https://github.com/rust-lang/rfcs/pull/2938